### PR TITLE
fix: dropdown options not visible in dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,6 +86,17 @@
       outline: none;
       border-color: #ffd54f;
     }
+    header select option {
+      background: #2a2a2a;
+      color: #e0e0e0;
+      padding: 8px;
+      font-size: 13px;
+    }
+    header select option:hover,
+    header select option:checked {
+      background: #3a3a3a;
+      color: #ffd54f;
+    }
     header .save-btn {
       background: var(--surface);
       border: 1px solid var(--border);


### PR DESCRIPTION
## Fix dropdown visibility issue

The example and React version dropdowns in the header were basically invisible - you could only see the options when hovering over them because they were using browser defaults with white text on white background.

### Changes
- Added explicit styling for `select option` elements
- Set background to `#2a2a2a` and text to `#e0e0e0` to match the existing dark theme
- Added hover/checked states with the yellow accent color for better UX

### Before
Options were invisible until hover (browser defaults)

### After  
Options are clearly visible and consistent with the rest of the UI

Pretty straightforward fix - just needed to override the browser defaults with our theme colors.Adds explicit styling for select option elements to match the dark theme. Options were only visible on hover due to browser default styles.