### PR TITLE
  feat: add backward navigation and seekable timeline

### DIFF
--- a/src/client/styles/workspace.css
+++ b/src/client/styles/workspace.css
@@ -561,17 +561,20 @@ main {
 .control-btn.play-btn.playing {
   color: #ffd54f;
 }
-.control-btn.step-btn {
+.control-btn.step-btn,
+.control-btn.step-btn-back {
   background: #ffd54f;
   color: #000;
   animation: pulse-step 1.5s ease-in-out infinite;
 }
-.control-btn.step-btn:hover:not(:disabled) {
+.control-btn.step-btn:hover:not(:disabled),
+.control-btn.step-btn-back:hover:not(:disabled) {
   background: #ffe566;
   color: #000;
   animation: none;
 }
-.control-btn.step-btn:disabled {
+.control-btn.step-btn:disabled,
+.control-btn.step-btn-back:disabled {
   background: transparent;
   color: var(--text);
   animation: none;
@@ -607,8 +610,8 @@ main {
   cursor: pointer;
   border: none;
 }
-.step-slider:disabled {
-  opacity: 0.5;
+.step-slider:hover {
+  cursor: pointer;
 }
 .step-info {
   font-size: 11px;

--- a/src/client/ui/LivePreview.jsx
+++ b/src/client/ui/LivePreview.jsx
@@ -34,6 +34,8 @@ export function LivePreview({
   isAtStart,
   isAtEnd,
   onStep,
+  onStepBack,
+  onSeek,
   onSkip,
   onReset
 }) {
@@ -60,9 +62,14 @@ export function LivePreview({
   const showPlaceholder = !clientModuleReady || cursor === 0;
 
   const handlePlayPause = () => setIsPlaying(!isPlaying);
+  const handleStepBack = () => { setIsPlaying(false); onStepBack(); };
   const handleStep = () => { setIsPlaying(false); onStep(); };
   const handleSkip = () => { setIsPlaying(false); onSkip(); };
   const handleReset = () => { setIsPlaying(false); onReset(); };
+  const handleSliderChange = (e) => {
+    setIsPlaying(false);
+    onSeek(parseInt(e.target.value, 10));
+  };
 
   let statusText = '';
   if (isAtStart) {
@@ -105,6 +112,16 @@ export function LivePreview({
             )}
           </button>
           <button
+            className={`control-btn ${!isAtStart ? 'step-btn-back' : ''}`}
+            onClick={handleStepBack}
+            disabled={isAtStart}
+            title="Step backward"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+              <path d="M15 6l-6 6 6 6"/>
+            </svg>
+          </button>
+          <button
             className={`control-btn ${!isAtEnd ? 'step-btn' : ''}`}
             onClick={handleStep}
             disabled={isAtEnd}
@@ -130,8 +147,7 @@ export function LivePreview({
           min="0"
           max={totalChunks}
           value={cursor}
-          onChange={() => {}}
-          disabled
+          onChange={handleSliderChange}
           className="step-slider"
         />
         <span className="step-info">{statusText}</span>

--- a/src/client/ui/Workspace.jsx
+++ b/src/client/ui/Workspace.jsx
@@ -40,6 +40,14 @@ export function Workspace({ initialServerCode, initialClientCode, onCodeChange }
     timeline.stepForward();
   }, [timeline]);
 
+  const handleStepBack = useCallback(() => {
+    timeline.stepBackward();
+  }, [timeline]);
+
+  const handleSeek = useCallback((position) => {
+    timeline.seekTo(position);
+  }, [timeline]);
+
   const handleSkip = useCallback(() => {
     timeline.skipToEntryEnd();
   }, [timeline]);
@@ -147,6 +155,8 @@ export function Workspace({ initialServerCode, initialClientCode, onCodeChange }
         isAtStart={isAtStart}
         isAtEnd={isAtEnd}
         onStep={handleStep}
+        onStepBack={handleStepBack}
+        onSeek={handleSeek}
         onSkip={handleSkip}
         onReset={handleReset}
       />

--- a/tests/navigation.spec.js
+++ b/tests/navigation.spec.js
@@ -1,0 +1,149 @@
+import { test, expect, beforeAll, afterAll } from 'vitest';
+import { chromium } from 'playwright';
+import { createHelpers } from './helpers.js';
+
+let browser, page, h;
+
+beforeAll(async () => {
+  browser = await chromium.launch();
+  page = await browser.newPage();
+  h = createHelpers(page);
+});
+
+afterAll(async () => {
+  await browser.close();
+});
+
+test('step backward returns to previous state', async () => {
+  await h.load('hello');
+
+  // Step forward and acknowledge preview changes
+  await h.stepAll();
+  await h.preview(); // Acknowledge preview change
+
+  const endCursor = await h.getCursor();
+  expect(endCursor.cursor).toBe(endCursor.total);
+
+  // Step backward
+  await h.stepBack();
+  const cursorAfterBack = await h.getCursor();
+  expect(cursorAfterBack.cursor).toBe(endCursor.total - 1);
+});
+
+test('step backward at start does nothing', async () => {
+  await h.load('hello');
+
+  // At start, cursor should be 0
+  const cursorAtStart = await h.getCursor();
+  expect(cursorAtStart.cursor).toBe(0);
+
+  // Step backward should return null (button disabled)
+  const result = await h.stepBack();
+  expect(result).toBe(null);
+
+  // Cursor should still be 0
+  const cursorAfter = await h.getCursor();
+  expect(cursorAfter.cursor).toBe(0);
+});
+
+test('step forward after backward continues correctly', async () => {
+  await h.load('hello');
+
+  // Step forward to end
+  await h.stepAll();
+  await h.preview(); // Acknowledge preview change
+  const endCursor = await h.getCursor();
+
+  // Step backward once
+  await h.stepBack();
+  await h.preview(); // Acknowledge preview change
+  const cursor2 = await h.getCursor();
+  expect(cursor2.cursor).toBe(endCursor.cursor - 1);
+
+  // Step forward again - should return to end
+  await h.stepAll();
+  await h.preview(); // Acknowledge preview change
+  const cursorForwardAgain = await h.getCursor();
+  expect(cursorForwardAgain.cursor).toBe(endCursor.cursor);
+});
+
+test('multiple step backwards work correctly', async () => {
+  await h.load('hello');
+
+  // Step forward to end
+  await h.stepAll();
+  await h.preview(); // Acknowledge preview change
+  const endCursor = await h.getCursor();
+  expect(endCursor.cursor).toBe(endCursor.total);
+
+  // Step backward multiple times
+  await h.stepBack();
+  await h.stepBack();
+  await h.stepBack();
+
+  const afterBackCursor = await h.getCursor();
+  expect(afterBackCursor.cursor).toBe(endCursor.total - 3);
+});
+
+test('seek to specific position works', async () => {
+  await h.load('hello');
+
+  // Get total chunks
+  const initial = await h.getCursor();
+  const total = initial.total;
+
+  // Seek to middle
+  const midpoint = Math.floor(total / 2);
+  await h.seek(midpoint);
+  const midCursor = await h.getCursor();
+  expect(midCursor.cursor).toBe(midpoint);
+
+  // Seek to end
+  await h.seek(total);
+  const endCursor = await h.getCursor();
+  expect(endCursor.cursor).toBe(total);
+
+  // Seek back to start
+  await h.seek(0);
+  const startCursor = await h.getCursor();
+  expect(startCursor.cursor).toBe(0);
+});
+
+test('seek backward replays stream correctly', async () => {
+  await h.load('hello');
+
+  // Step to end and capture tree
+  const treeAtEnd = await h.stepAll();
+  await h.preview(); // Acknowledge preview change
+
+  // Seek backward to position 1
+  await h.seek(1);
+  await h.preview(); // Acknowledge preview change
+  const cursor1 = await h.getCursor();
+  expect(cursor1.cursor).toBe(1);
+
+  // Step forward to end again - tree should match (using stepAll to properly complete)
+  await h.stepAll();
+  await h.preview(); // Acknowledge preview change
+  const treeAtEndAgain = await h.tree();
+  expect(treeAtEndAgain).toBe(treeAtEnd);
+});
+
+test('preview updates correctly after backward navigation', async () => {
+  await h.load('hello');
+
+  // Step to show content
+  await h.stepAll();
+  const previewAtEnd = await h.preview();
+  expect(previewAtEnd).toMatchInlineSnapshot(`"Hello World"`);
+
+  // Seek back to start
+  await h.seek(0);
+  const previewAtStart = await h.preview();
+  expect(previewAtStart).toMatchInlineSnapshot(`"Step to begin..."`);
+
+  // Step forward again
+  await h.stepAll();
+  const previewAtEndAgain = await h.preview();
+  expect(previewAtEndAgain).toBe(previewAtEnd);
+});


### PR DESCRIPTION


https://github.com/user-attachments/assets/6136a091-f422-4dfd-bec4-61c6f86f6f2f


## Summary
  - Add step backward button to navigate to previous state
  - Make timeline slider interactive for seeking to any position
  - Add 7 new tests for navigation functionality

  ## Details
  Currently the RSC Explorer only supports navigating forward through the Flight stream. This PR adds the ability to navigate backward, which is useful for debugging and understanding how the stream builds up over time.

  ### Changes
  - **SteppableStream**: Added `reset()` method to recreate the stream for replaying
  - **Timeline**: Added `stepBackward()` and `seekTo(position)` methods with `_releaseNext()` helper
  - **LivePreview**: Added step backward button and made slider interactive
  - **Tests**: 7 new tests covering step backward, seek, and edge cases

  ### How it works
  Backward navigation works by resetting all streams and replaying from the beginning to the target position. This is necessary because `ReadableStream` only flows forward.

  ## Test plan
  - [x] All existing tests pass
  - [x] New navigation tests pass
  - [x] Manual testing: step forward, step backward, drag slider