### PR TITLE
Fix transition in pagination sample

### DIFF
--- a/src/client/samples.ts
+++ b/src/client/samples.ts
@@ -197,9 +197,11 @@ function usePagination(initialItems, initialCursor, action) {
   const formAction = () => {
     startTransition(async () => {
       const result = await action(cursor)
-      setItems(prev => [...prev, ...result.newItems])
-      setCursor(result.cursor)
-      setHasMore(result.hasMore)
+      startTransition(() => {
+        setItems(prev => [...prev, ...result.newItems])
+        setCursor(result.cursor)
+        setHasMore(result.hasMore)
+      })
     })
   }
 


### PR DESCRIPTION
See https://react.dev/reference/react/useTransition#react-doesnt-treat-my-state-update-after-await-as-a-transition

Currently, these state updates aren't treated as part of the transition because the context is lost after the `await`. The fix is to re-wrap them in `startTransition`.

The issue isn't particularly noticeable in the demo but I thought it worth fixing because this is a common source of confusion with transitions and modern React, and code that shows up in educational material like this often gets treated as a source of truth.

(This tool is great and illustrative; thanks for putting it together!)