### PR TITLE
Fix double border-radius

### DIFF
--- a/embed.html
+++ b/embed.html
@@ -36,7 +36,6 @@
         font-family: -apple-system, BlinkMacSystemFont, "Inter", sans-serif;
         background: var(--bg);
         color: var(--text);
-        border-radius: 8px;
       }
       #embed-root {
         display: flex;


### PR DESCRIPTION
border-radius inside the frame doesn't look good if someone puts a border or border-radius outside the frame.

This fixes this artifact on overreacted:

<img width="222" height="226" alt="Image" src="https://github.com/user-attachments/assets/2675b575-de0c-4227-9aed-50b9eee490e7" />