### PR TITLE
feat: Add autoskip

### DIFF
--- a/src/client/ui/LivePreview.css
+++ b/src/client/ui/LivePreview.css
@@ -138,6 +138,10 @@
   white-space: nowrap;
 }
 
+.LivePreview-subcontrols {
+  padding: 8px 12px;
+}
+
 .LivePreview-container {
   flex: 1;
   padding: 20px;

--- a/src/client/ui/LivePreview.tsx
+++ b/src/client/ui/LivePreview.tsx
@@ -51,6 +51,8 @@ type LivePreviewProps = {
   onStep: () => void;
   onSkip: () => void;
   onReset: () => void;
+  autoSkip: boolean;
+  setAutoSkip: (enabled: boolean) => void;
 };
 
 export function LivePreview({
@@ -63,6 +65,8 @@ export function LivePreview({
   onStep,
   onSkip,
   onReset,
+  autoSkip,
+  setAutoSkip,
 }: LivePreviewProps): React.ReactElement {
   const renderEntry = entries[0];
   const flightPromise = renderEntry?.flightPromise;
@@ -204,6 +208,22 @@ export function LivePreview({
         >
           {statusText}
         </span>
+      </div>
+      <div>
+        <label id="autoSkip">
+          <input
+            aria-label="autoSkip"
+            type="checkbox"
+            checked={autoSkip}
+            onChange={(e) => {
+              if (e.target.checked) {
+                handleSkip();
+              }
+              setAutoSkip(e.target.checked);
+            }}
+          />
+          Auto Skip
+        </label>
       </div>
       <div className="LivePreview-container" data-testid="preview-container">
         {isLoading ? (

--- a/src/client/ui/LivePreview.tsx
+++ b/src/client/ui/LivePreview.tsx
@@ -209,7 +209,7 @@ export function LivePreview({
           {statusText}
         </span>
       </div>
-      <div>
+      <div className="LivePreview-subcontrols">
         <label id="autoSkip">
           <input
             aria-label="autoSkip"

--- a/src/client/ui/Workspace.tsx
+++ b/src/client/ui/Workspace.tsx
@@ -59,7 +59,7 @@ export function Workspace({
 
   useEffect(() => {
     session?.setAutoSkip(autoSkip);
-  }, [autoSkip]);
+  }, [session, autoSkip]);
 
   const { entries, cursor, totalChunks, isAtStart, isAtEnd } = useSyncExternalStore(
     timeline.subscribe,

--- a/src/client/ui/Workspace.tsx
+++ b/src/client/ui/Workspace.tsx
@@ -21,6 +21,7 @@ export function Workspace({
   const [clientCode, setClientCode] = useState(initialClientCode);
   const [resetKey, setResetKey] = useState(0);
   const [session, setSession] = useState<WorkspaceSession | null>(null);
+  const [autoSkip, setAutoSkip] = useState<boolean>(false);
 
   useEffect(() => {
     const abort = new AbortController();
@@ -50,10 +51,16 @@ export function Workspace({
   }
 
   function reset() {
+    setAutoSkip(false);
     setResetKey((k) => k + 1);
   }
 
   const timeline = session?.timeline ?? loadingTimeline;
+
+  useEffect(() => {
+    session?.setAutoSkip(autoSkip);
+  }, [autoSkip]);
+
   const { entries, cursor, totalChunks, isAtStart, isAtEnd } = useSyncExternalStore(
     timeline.subscribe,
     timeline.getSnapshot,
@@ -102,6 +109,8 @@ export function Workspace({
           onStep={timeline.stepForward}
           onSkip={timeline.skipToEntryEnd}
           onReset={reset}
+          autoSkip={autoSkip}
+          setAutoSkip={setAutoSkip}
         />
       </div>
     </main>

--- a/src/client/workspace-session.ts
+++ b/src/client/workspace-session.ts
@@ -28,6 +28,7 @@ export const loadingTimeline = {
   getSnapshot: () => emptySnapshot,
   stepForward: () => {},
   skipToEntryEnd: () => {},
+  setAutoSkip: () => {},
 };
 
 export class WorkspaceSession {
@@ -35,6 +36,7 @@ export class WorkspaceSession {
   readonly state: SessionState;
   readonly id: number = lastId++;
   private worker: WorkerClient;
+  private autoSkip: boolean = false;
 
   private constructor(worker: WorkerClient, state: SessionState) {
     this.worker = worker;
@@ -104,6 +106,9 @@ export class WorkspaceSession {
       stream = SteppableStream.fromError(error);
     }
     this.timeline.addAction(actionName, argsDisplay, stream);
+    if (this.autoSkip) {
+      this.timeline.skipToEntryEnd();
+    }
     if (stream.error) {
       throw stream.error;
     }
@@ -123,5 +128,9 @@ export class WorkspaceSession {
 
   addRawAction = async (actionName: string, rawPayload: string): Promise<void> => {
     await this.runAction(actionName, { type: "formdata", data: rawPayload }, rawPayload);
+  };
+
+  setAutoSkip = (enabled: boolean): void => {
+    this.autoSkip = enabled;
   };
 }


### PR DESCRIPTION
It might be nice to auto skip actions to see the app behavior without interruptions. 

https://github.com/user-attachments/assets/447737e8-2492-4544-9ede-3c7cf9a1cca5

## Changes

Add `autoSkip` property to `WorkspaceSession` and keep it synced with checkbox state using an effect. In `runAction`, do
```
this.timeline.addAction(actionName, argsDisplay, stream);
if (this.autoSkip) {
  this.timeline.skipToEntryEnd();
}
```


