### PR TITLE
Add resizable panes to workspace

### DIFF
--- a/src/client/ui/ResizablePanes.css
+++ b/src/client/ui/ResizablePanes.css
@@ -4,8 +4,8 @@
   flex: 1;
   min-height: 0;
   display: grid;
-  grid-template-columns: var(--col-percent) 0 calc(100% - var(--col-percent));
-  grid-template-rows: var(--row-percent) 0 calc(100% - var(--row-percent));
+  grid-template-columns: var(--col-percent) calc(100% - var(--col-percent));
+  grid-template-rows: var(--row-percent) calc(100% - var(--row-percent));
   overflow: hidden;
   position: relative;
 }
@@ -32,136 +32,69 @@
 }
 
 .ResizablePanes-topRight {
-  grid-column: 3;
+  grid-column: 2;
   grid-row: 1;
   border-bottom: 1px solid var(--border);
 }
 
 .ResizablePanes-bottomLeft {
   grid-column: 1;
-  grid-row: 3;
+  grid-row: 2;
   border-right: 1px solid var(--border);
 }
 
 .ResizablePanes-bottomRight {
-  grid-column: 3;
-  grid-row: 3;
+  grid-column: 2;
+  grid-row: 2;
 }
 
-/* Resize handles */
-.ResizablePanes-handle {
-  position: relative;
+/* Dividers - continuous handles spanning full height/width */
+.ResizablePanes-divider {
+  position: absolute;
   z-index: 10;
   background: transparent;
   transition: background-color 0.15s ease;
 }
 
-.ResizablePanes-handle:hover,
-.ResizablePanes-handle:focus-visible {
+.ResizablePanes-divider:hover,
+.ResizablePanes-divider:focus-visible {
   background: var(--border);
 }
 
-.ResizablePanes-handle:focus-visible {
+.ResizablePanes-divider:focus-visible {
   outline: 2px solid #ffd54f;
-  outline-offset: -2px;
+  outline-offset: -1px;
 }
 
-/* Vertical handles (for horizontal resizing - col width) */
-.ResizablePanes-handle--vertical {
-  grid-column: 2;
+/* Vertical divider (full height) - controls column split */
+.ResizablePanes-divider--vertical {
+  top: 0;
+  bottom: 0;
+  left: var(--col-percent);
   width: 5px;
   margin-left: -2px;
-  margin-right: -3px;
   cursor: col-resize;
 }
 
-.ResizablePanes-handle--vertical.ResizablePanes-handle--top {
-  grid-row: 1;
-}
-
-.ResizablePanes-handle--vertical.ResizablePanes-handle--bottom {
-  grid-row: 3;
-}
-
-/* Horizontal handles (for vertical resizing - row height) */
-.ResizablePanes-handle--horizontal {
-  grid-row: 2;
+/* Horizontal divider (full width) - controls row split */
+.ResizablePanes-divider--horizontal {
+  left: 0;
+  right: 0;
+  top: var(--row-percent);
   height: 5px;
   margin-top: -2px;
-  margin-bottom: -3px;
   cursor: row-resize;
-}
-
-.ResizablePanes-handle--horizontal.ResizablePanes-handle--left {
-  grid-column: 1;
-}
-
-.ResizablePanes-handle--horizontal.ResizablePanes-handle--right {
-  grid-column: 3;
-}
-
-/* Intersection handle (center) */
-.ResizablePanes-handle--intersection {
-  grid-column: 2;
-  grid-row: 2;
-  width: 9px;
-  height: 9px;
-  margin-left: -4px;
-  margin-top: -4px;
-  cursor: move;
-  border-radius: 2px;
-  z-index: 11;
-}
-
-.ResizablePanes-handle--intersection:hover,
-.ResizablePanes-handle--intersection:focus-visible {
-  background: #444;
-}
-
-/* Visual indicator for the intersection */
-.ResizablePanes-handle--intersection::before {
-  content: "";
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 5px;
-  height: 5px;
-  transform: translate(-50%, -50%);
-  background: var(--text-dim);
-  border-radius: 50%;
-  opacity: 0;
-  transition: opacity 0.15s ease;
-}
-
-.ResizablePanes-handle--intersection:hover::before,
-.ResizablePanes-handle--intersection:focus-visible::before {
-  opacity: 1;
 }
 
 /* Touch device improvements - larger hit targets */
 @media (pointer: coarse) {
-  .ResizablePanes-handle--vertical {
+  .ResizablePanes-divider--vertical {
     width: 16px;
     margin-left: -8px;
-    margin-right: -8px;
   }
 
-  .ResizablePanes-handle--horizontal {
+  .ResizablePanes-divider--horizontal {
     height: 16px;
     margin-top: -8px;
-    margin-bottom: -8px;
-  }
-
-  .ResizablePanes-handle--intersection {
-    width: 24px;
-    height: 24px;
-    margin-left: -12px;
-    margin-top: -12px;
-  }
-
-  .ResizablePanes-handle--intersection::before {
-    width: 8px;
-    height: 8px;
-    opacity: 0.5;
   }
 }

--- a/src/client/ui/ResizablePanes.css
+++ b/src/client/ui/ResizablePanes.css
@@ -1,0 +1,139 @@
+/* ResizablePanes component styles */
+
+.ResizablePanes {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: var(--col-percent) 0 calc(100% - var(--col-percent));
+  grid-template-rows: var(--row-percent) 0 calc(100% - var(--row-percent));
+  overflow: hidden;
+  position: relative;
+}
+
+/* Pane containers */
+.ResizablePanes-pane {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.ResizablePanes-pane > * {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+}
+
+.ResizablePanes-topLeft {
+  grid-column: 1;
+  grid-row: 1;
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.ResizablePanes-topRight {
+  grid-column: 3;
+  grid-row: 1;
+  border-bottom: 1px solid var(--border);
+}
+
+.ResizablePanes-bottomLeft {
+  grid-column: 1;
+  grid-row: 3;
+  border-right: 1px solid var(--border);
+}
+
+.ResizablePanes-bottomRight {
+  grid-column: 3;
+  grid-row: 3;
+}
+
+/* Resize handles */
+.ResizablePanes-handle {
+  position: relative;
+  z-index: 10;
+  background: transparent;
+  transition: background-color 0.15s ease;
+}
+
+.ResizablePanes-handle:hover,
+.ResizablePanes-handle:focus-visible {
+  background: var(--border);
+}
+
+.ResizablePanes-handle:focus-visible {
+  outline: 2px solid #ffd54f;
+  outline-offset: -2px;
+}
+
+/* Vertical handles (for horizontal resizing - col width) */
+.ResizablePanes-handle--vertical {
+  grid-column: 2;
+  width: 5px;
+  margin-left: -2px;
+  margin-right: -3px;
+  cursor: col-resize;
+}
+
+.ResizablePanes-handle--vertical.ResizablePanes-handle--top {
+  grid-row: 1;
+}
+
+.ResizablePanes-handle--vertical.ResizablePanes-handle--bottom {
+  grid-row: 3;
+}
+
+/* Horizontal handles (for vertical resizing - row height) */
+.ResizablePanes-handle--horizontal {
+  grid-row: 2;
+  height: 5px;
+  margin-top: -2px;
+  margin-bottom: -3px;
+  cursor: row-resize;
+}
+
+.ResizablePanes-handle--horizontal.ResizablePanes-handle--left {
+  grid-column: 1;
+}
+
+.ResizablePanes-handle--horizontal.ResizablePanes-handle--right {
+  grid-column: 3;
+}
+
+/* Intersection handle (center) */
+.ResizablePanes-handle--intersection {
+  grid-column: 2;
+  grid-row: 2;
+  width: 9px;
+  height: 9px;
+  margin-left: -4px;
+  margin-top: -4px;
+  cursor: move;
+  border-radius: 2px;
+  z-index: 11;
+}
+
+.ResizablePanes-handle--intersection:hover,
+.ResizablePanes-handle--intersection:focus-visible {
+  background: #444;
+}
+
+/* Visual indicator for the intersection */
+.ResizablePanes-handle--intersection::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 5px;
+  height: 5px;
+  transform: translate(-50%, -50%);
+  background: var(--text-dim);
+  border-radius: 50%;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.ResizablePanes-handle--intersection:hover::before,
+.ResizablePanes-handle--intersection:focus-visible::before {
+  opacity: 1;
+}

--- a/src/client/ui/ResizablePanes.css
+++ b/src/client/ui/ResizablePanes.css
@@ -137,3 +137,31 @@
 .ResizablePanes-handle--intersection:focus-visible::before {
   opacity: 1;
 }
+
+/* Touch device improvements - larger hit targets */
+@media (pointer: coarse) {
+  .ResizablePanes-handle--vertical {
+    width: 16px;
+    margin-left: -8px;
+    margin-right: -8px;
+  }
+
+  .ResizablePanes-handle--horizontal {
+    height: 16px;
+    margin-top: -8px;
+    margin-bottom: -8px;
+  }
+
+  .ResizablePanes-handle--intersection {
+    width: 24px;
+    height: 24px;
+    margin-left: -12px;
+    margin-top: -12px;
+  }
+
+  .ResizablePanes-handle--intersection::before {
+    width: 8px;
+    height: 8px;
+    opacity: 0.5;
+  }
+}

--- a/src/client/ui/ResizablePanes.tsx
+++ b/src/client/ui/ResizablePanes.tsx
@@ -1,0 +1,193 @@
+import React, {
+  useRef,
+  useState,
+  useCallback,
+  useEffect,
+  type ReactNode,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
+import "./ResizablePanes.css";
+
+type ResizablePanesProps = {
+  topLeft: ReactNode;
+  topRight: ReactNode;
+  bottomLeft: ReactNode;
+  bottomRight: ReactNode;
+};
+
+// Constants for sizing constraints
+const MIN_SIZE_PERCENT = 20; // Minimum 20% for any pane
+const MAX_SIZE_PERCENT = 80; // Maximum 80% for any pane
+
+type DragState = {
+  type: "horizontal" | "vertical" | "both";
+  startX: number;
+  startY: number;
+  startColPercent: number;
+  startRowPercent: number;
+};
+
+export function ResizablePanes({
+  topLeft,
+  topRight,
+  bottomLeft,
+  bottomRight,
+}: ResizablePanesProps): React.ReactElement {
+  // Column split: percentage of width for left column (0-100)
+  const [colPercent, setColPercent] = useState(50);
+  // Row split: percentage of height for top row (0-100)
+  const [rowPercent, setRowPercent] = useState(50);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const dragStateRef = useRef<DragState | null>(null);
+
+  const clamp = (value: number): number => {
+    return Math.min(MAX_SIZE_PERCENT, Math.max(MIN_SIZE_PERCENT, value));
+  };
+
+  const handleMouseDown = useCallback(
+    (type: "horizontal" | "vertical" | "both") => (e: ReactMouseEvent) => {
+      e.preventDefault();
+      dragStateRef.current = {
+        type,
+        startX: e.clientX,
+        startY: e.clientY,
+        startColPercent: colPercent,
+        startRowPercent: rowPercent,
+      };
+      document.body.style.cursor =
+        type === "horizontal" ? "col-resize" : type === "vertical" ? "row-resize" : "move";
+      document.body.style.userSelect = "none";
+    },
+    [colPercent, rowPercent],
+  );
+
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent): void => {
+      const dragState = dragStateRef.current;
+      if (!dragState || !containerRef.current) return;
+
+      const rect = containerRef.current.getBoundingClientRect();
+
+      if (dragState.type === "horizontal" || dragState.type === "both") {
+        const deltaX = e.clientX - dragState.startX;
+        const deltaPercent = (deltaX / rect.width) * 100;
+        setColPercent(clamp(dragState.startColPercent + deltaPercent));
+      }
+
+      if (dragState.type === "vertical" || dragState.type === "both") {
+        const deltaY = e.clientY - dragState.startY;
+        const deltaPercent = (deltaY / rect.height) * 100;
+        setRowPercent(clamp(dragState.startRowPercent + deltaPercent));
+      }
+    };
+
+    const handleMouseUp = (): void => {
+      if (dragStateRef.current) {
+        dragStateRef.current = null;
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+      }
+    };
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, []);
+
+  // Reset to 50/50 on double-click
+  const handleDoubleClick = useCallback(
+    (type: "horizontal" | "vertical" | "both") => () => {
+      if (type === "horizontal" || type === "both") {
+        setColPercent(50);
+      }
+      if (type === "vertical" || type === "both") {
+        setRowPercent(50);
+      }
+    },
+    [],
+  );
+
+  return (
+    <div
+      className="ResizablePanes"
+      ref={containerRef}
+      style={
+        {
+          "--col-percent": `${colPercent}%`,
+          "--row-percent": `${rowPercent}%`,
+        } as React.CSSProperties
+      }
+    >
+      {/* Top-left pane */}
+      <div className="ResizablePanes-pane ResizablePanes-topLeft">{topLeft}</div>
+
+      {/* Vertical handle (between top-left and top-right) */}
+      <div
+        className="ResizablePanes-handle ResizablePanes-handle--vertical ResizablePanes-handle--top"
+        onMouseDown={handleMouseDown("horizontal")}
+        onDoubleClick={handleDoubleClick("horizontal")}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize left and right panes"
+        tabIndex={0}
+      />
+
+      {/* Top-right pane */}
+      <div className="ResizablePanes-pane ResizablePanes-topRight">{topRight}</div>
+
+      {/* Horizontal handle (between top row and bottom row) */}
+      <div
+        className="ResizablePanes-handle ResizablePanes-handle--horizontal ResizablePanes-handle--left"
+        onMouseDown={handleMouseDown("vertical")}
+        onDoubleClick={handleDoubleClick("vertical")}
+        role="separator"
+        aria-orientation="horizontal"
+        aria-label="Resize top and bottom panes"
+        tabIndex={0}
+      />
+
+      {/* Center intersection handle */}
+      <div
+        className="ResizablePanes-handle ResizablePanes-handle--intersection"
+        onMouseDown={handleMouseDown("both")}
+        onDoubleClick={handleDoubleClick("both")}
+        role="separator"
+        aria-label="Resize all panes"
+        tabIndex={0}
+      />
+
+      {/* Horizontal handle (right side) */}
+      <div
+        className="ResizablePanes-handle ResizablePanes-handle--horizontal ResizablePanes-handle--right"
+        onMouseDown={handleMouseDown("vertical")}
+        onDoubleClick={handleDoubleClick("vertical")}
+        role="separator"
+        aria-orientation="horizontal"
+        aria-label="Resize top and bottom panes"
+        tabIndex={0}
+      />
+
+      {/* Bottom-left pane */}
+      <div className="ResizablePanes-pane ResizablePanes-bottomLeft">{bottomLeft}</div>
+
+      {/* Vertical handle (between bottom-left and bottom-right) */}
+      <div
+        className="ResizablePanes-handle ResizablePanes-handle--vertical ResizablePanes-handle--bottom"
+        onMouseDown={handleMouseDown("horizontal")}
+        onDoubleClick={handleDoubleClick("horizontal")}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize left and right panes"
+        tabIndex={0}
+      />
+
+      {/* Bottom-right pane */}
+      <div className="ResizablePanes-pane ResizablePanes-bottomRight">{bottomRight}</div>
+    </div>
+  );
+}

--- a/src/client/ui/Workspace.css
+++ b/src/client/ui/Workspace.css
@@ -3,53 +3,8 @@
 .Workspace {
   flex: 1;
   min-height: 0;
-  display: grid;
-  grid-template-columns: 50% 50%;
-  grid-template-rows: 50% 50%;
-  grid-template-areas:
-    "server flight"
-    "client preview";
-  overflow: hidden;
-}
-
-/* Grid positioning */
-
-.Workspace-server,
-.Workspace-client,
-.Workspace-flight,
-.Workspace-preview {
   display: flex;
-  min-width: 0;
-  min-height: 0;
-}
-
-.Workspace-server > *,
-.Workspace-client > *,
-.Workspace-flight > *,
-.Workspace-preview > * {
-  flex: 1;
-  min-width: 0;
-  min-height: 0;
-}
-
-.Workspace-server {
-  grid-area: server;
-  border-right: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
-}
-
-.Workspace-client {
-  grid-area: client;
-  border-right: 1px solid var(--border);
-}
-
-.Workspace-flight {
-  grid-area: flight;
-  border-bottom: 1px solid var(--border);
-}
-
-.Workspace-preview {
-  grid-area: preview;
+  overflow: hidden;
 }
 
 /* Loading states */

--- a/src/client/ui/Workspace.tsx
+++ b/src/client/ui/Workspace.tsx
@@ -4,6 +4,7 @@ import { CodeEditor } from "./CodeEditor.tsx";
 import { FlightLog } from "./FlightLog.tsx";
 import { LivePreview } from "./LivePreview.tsx";
 import { Pane } from "./Pane.tsx";
+import { ResizablePanes } from "./ResizablePanes.tsx";
 import "./Workspace.css";
 
 type WorkspaceProps = {
@@ -65,47 +66,49 @@ export function Workspace({
 
   return (
     <main className="Workspace">
-      <div className="Workspace-server">
-        <CodeEditor label="server" defaultValue={serverCode} onChange={handleServerChange} />
-      </div>
-      <div className="Workspace-client">
-        <CodeEditor label="client" defaultValue={clientCode} onChange={handleClientChange} />
-      </div>
-      <div className="Workspace-flight">
-        <Pane label="flight">
-          {isLoading ? (
-            <div className="Workspace-loadingOutput">
-              <span className="Workspace-loadingEmpty Workspace-loadingEmpty--waiting">
-                Loading
-              </span>
-            </div>
-          ) : isError ? (
-            <pre className="Workspace-errorOutput">{session.state.message}</pre>
-          ) : (
-            <FlightLog
-              entries={entries}
-              cursor={cursor}
-              availableActions={session.state.availableActions}
-              onAddRawAction={session.addRawAction}
-              onDeleteEntry={session.timeline.deleteEntry}
-            />
-          )}
-        </Pane>
-      </div>
-      <div className="Workspace-preview">
-        <LivePreview
-          entries={entries}
-          cursor={cursor}
-          totalChunks={totalChunks}
-          isAtStart={isAtStart}
-          isAtEnd={isAtEnd}
-          isStreaming={isStreaming}
-          isLoading={isLoading || isError}
-          onStep={timeline.stepForward}
-          onSkip={timeline.skipToEntryEnd}
-          onReset={reset}
-        />
-      </div>
+      <ResizablePanes
+        topLeft={
+          <CodeEditor label="server" defaultValue={serverCode} onChange={handleServerChange} />
+        }
+        bottomLeft={
+          <CodeEditor label="client" defaultValue={clientCode} onChange={handleClientChange} />
+        }
+        topRight={
+          <Pane label="flight">
+            {isLoading ? (
+              <div className="Workspace-loadingOutput">
+                <span className="Workspace-loadingEmpty Workspace-loadingEmpty--waiting">
+                  Loading
+                </span>
+              </div>
+            ) : isError ? (
+              <pre className="Workspace-errorOutput">{session.state.message}</pre>
+            ) : (
+              <FlightLog
+                entries={entries}
+                cursor={cursor}
+                availableActions={session.state.availableActions}
+                onAddRawAction={session.addRawAction}
+                onDeleteEntry={session.timeline.deleteEntry}
+              />
+            )}
+          </Pane>
+        }
+        bottomRight={
+          <LivePreview
+            entries={entries}
+            cursor={cursor}
+            totalChunks={totalChunks}
+            isAtStart={isAtStart}
+            isAtEnd={isAtEnd}
+            isStreaming={isStreaming}
+            isLoading={isLoading || isError}
+            onStep={timeline.stepForward}
+            onSkip={timeline.skipToEntryEnd}
+            onReset={reset}
+          />
+        }
+      />
     </main>
   );
 }


### PR DESCRIPTION
Hey! This PR adds the ability to resize the 4 workspace panes (server, client, flight, preview).

I've been using the explorer and found it a bit annoying that the panes are fixed at 50/50 - sometimes you want more space for the flight log or to focus on the preview. So I added draggable dividers between them.

**What this does:**
1. You can drag any edge between panes to resize horizontally or vertically
2. There's a small handle in the center where all 4 panes meet - drag that to resize everything at once
3. Double-click any handle to reset back to 50/50
4. Panes are clamped to 20-80% so you can't accidentally collapse them completely 

**Technical notes:**
1. Created a new `ResizablePanes` component that uses CSS Grid with custom properties for dynamic sizing
2. Added proper ARIA roles and keyboard accessibility (handles are focusable)
3. No external dependencies - just vanilla React + CSS

**DEMO:**
https://github.com/user-attachments/assets/49c7de00-b591-4a69-8478-3995a20f7bca


Let me know if you have any feedback!