### PR TITLE
Fix non-existent Thenable type

### DIFF
--- a/types/react-server-dom-webpack.d.ts
+++ b/types/react-server-dom-webpack.d.ts
@@ -2,7 +2,7 @@
 // Based on Flow types from React source
 
 declare module "react-server-dom-webpack/server" {
-  import type { Thenable, ReactNode } from "react";
+  import type { ReactNode } from "react";
 
   export type TemporaryReferenceSet = Set<unknown>;
 
@@ -52,7 +52,7 @@ declare module "react-server-dom-webpack/server" {
     body: string | FormData,
     webpackMap: ServerManifest,
     options?: { temporaryReferences?: TemporaryReferenceSet },
-  ): Thenable<T>;
+  ): PromiseLike<T>;
 
   export function decodeAction<T = unknown>(
     body: FormData,
@@ -83,8 +83,6 @@ declare module "react-server-dom-webpack/server" {
 }
 
 declare module "react-server-dom-webpack/client" {
-  import type { Thenable } from "react";
-
   export type TemporaryReferenceSet = Set<unknown>;
 
   export type CallServerCallback = (id: string, args: unknown[]) => Promise<unknown>;
@@ -108,12 +106,12 @@ declare module "react-server-dom-webpack/client" {
   export function createFromReadableStream<T = unknown>(
     stream: ReadableStream,
     options?: Options,
-  ): Thenable<T>;
+  ): PromiseLike<T>;
 
   export function createFromFetch<T = unknown>(
     promiseForResponse: Promise<Response>,
     options?: Options,
-  ): Thenable<T>;
+  ): PromiseLike<T>;
 
   export function encodeReply(
     value: unknown,


### PR DESCRIPTION
# Why

Hey, thanks for this repository! It's a great reference for understanding React Flight. My fun little side project I'm working on right now is a mini React Server Components framework 😉. For this framework of mine, I copy pasted your types file for RSDW from `types/react-server-dom-webpack.d.ts`. 

What I noticed however, is that `Thenable` is no longer a type exported from @react/types. [Indeed I found a corresponding DefinitelyTyped PR removing this type, instead advocating for the use of `PromiseLike` in TypeScript.
](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69567)


# What changed

🪓 use-cases of `Thenable` and replace them with the built-in `PromiseLike` type.

# Test plan

I ran `npm run lint` and it passes 😁